### PR TITLE
FIX: do not discard volatile qualifier in casts

### DIFF
--- a/bearlyml/inc/bearlyml_hal_clint.h
+++ b/bearlyml/inc/bearlyml_hal_clint.h
@@ -18,11 +18,11 @@ extern "C" {
 #include "bearlyml_hal.h"
 
 static inline void HAL_CLINT_clearSoftwareInterrupt(uint32_t hartid) {
-  CLEAR_BITS(*(uint32_t *)((&CLINT->MSIP0) + 4 * hartid), 1U);
+  CLEAR_BITS(*(volatile uint32_t *)((&CLINT->MSIP0) + 4 * hartid), 1U);
 }
 
 static inline void HAL_CLINT_triggerSoftwareInterrupt(uint32_t hartid) {
-  SET_BITS(*(uint32_t *)((&CLINT->MSIP0) + 4 * hartid), 1U);
+  SET_BITS(*(volatile uint32_t *)((&CLINT->MSIP0) + 4 * hartid), 1U);
 }
 
 uint64_t HAL_CLINT_getTime();

--- a/bearlyml/src/bearlyml_hal_clint.c
+++ b/bearlyml/src/bearlyml_hal_clint.c
@@ -15,16 +15,15 @@ uint64_t HAL_CLINT_getTime() {
   uint32_t time_hi;
 
   do {
-    time_hi = *((uint32_t *)(&CLINT->MTIME) + 1);
-    time_lo = *((uint32_t *)(&CLINT->MTIME));
-  } while (*((uint32_t *)(&CLINT->MTIME) + 1) != time_hi);
+    time_hi = *((volatile uint32_t *)(&CLINT->MTIME) + 1);
+    time_lo = *((volatile uint32_t *)(&CLINT->MTIME));
+  } while (*((volatile uint32_t *)(&CLINT->MTIME) + 1) != time_hi);
 
   return (((uint64_t)time_hi) << 32U) | time_lo;
 }
 
 void HAL_CLINT_setTimerInterruptTarget(uint32_t hartid, uint64_t time) {
-  *((uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid + 1) = 0xffffffff;
-  *((uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid) = (uint32_t)time;
-  *((uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid + 1) = (uint32_t)(time >> 32);
+  *((volatile uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid + 1) = 0xffffffff;
+  *((volatile uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid) = (uint32_t)time;
+  *((volatile uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid + 1) = (uint32_t)(time >> 32);
 }
-

--- a/examplechip/inc/examplechip_hal_clint.h
+++ b/examplechip/inc/examplechip_hal_clint.h
@@ -19,11 +19,11 @@ extern "C" {
 
 
 static inline void HAL_CLINT_clearSoftwareInterrupt(uint32_t hartid) {
-  CLEAR_BITS(*(uint32_t *)((&CLINT->MSIP0) + 4 * hartid), 1U);
+  CLEAR_BITS(*(volatile uint32_t *)((&CLINT->MSIP0) + 4 * hartid), 1U);
 }
 
 static inline void HAL_CLINT_triggerSoftwareInterrupt(uint32_t hartid) {
-  SET_BITS(*(uint32_t *)((&CLINT->MSIP0) + 4 * hartid), 1U);
+  SET_BITS(*(volatile uint32_t *)((&CLINT->MSIP0) + 4 * hartid), 1U);
 }
 
 uint64_t HAL_CLINT_getTime();

--- a/examplechip/src/examplechip_hal_clint.c
+++ b/examplechip/src/examplechip_hal_clint.c
@@ -15,15 +15,15 @@ uint64_t HAL_CLINT_getTime() {
   uint32_t time_hi;
 
   do {
-    time_hi = *((uint32_t *)(&CLINT->MTIME) + 1);
-    time_lo = *((uint32_t *)(&CLINT->MTIME));
-  } while (*((uint32_t *)(&CLINT->MTIME) + 1) != time_hi);
+    time_hi = *((volatile uint32_t *)(&CLINT->MTIME) + 1);
+    time_lo = *((volatile uint32_t *)(&CLINT->MTIME));
+  } while (*((volatile uint32_t *)(&CLINT->MTIME) + 1) != time_hi);
 
   return (((uint64_t)time_hi) << 32U) | time_lo;
 }
 
 void HAL_CLINT_setTimerInterruptTarget(uint32_t hartid, uint64_t time) {
-  *((uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid + 1) = 0xffffffff;
-  *((uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid) = (uint32_t)time;
-  *((uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid + 1) = (uint32_t)(time >> 32);
+  *((volatile uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid + 1) = 0xffffffff;
+  *((volatile uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid) = (uint32_t)time;
+  *((volatile uint32_t *)(&CLINT->MTIMECMP0) + 4 * hartid + 1) = (uint32_t)(time >> 32);
 }


### PR DESCRIPTION
Pointer casting to a pointer-to-nonvolatile-type silently discards volatile qualifiers; the pointers should be volatile-qualified.

Previously, the compiler would optimize out all the synchronization code into simple reads / writes (which would be liable to problems from torn reads / writes).

Compiler explorer link showing reads/writes getting optimized out: https://godbolt.org/z/z6ao5jeTM

We may also want to add `-Wcast-qual`, which warns on any pointer cast that changes cv-qualifiers (const and volatile).