### PR TITLE
FIX: fix CLINT code

### DIFF
--- a/common/inc/hal_clint.h
+++ b/common/inc/hal_clint.h
@@ -20,11 +20,11 @@ extern "C" {
 
 
 static inline void HAL_CLINT_clearSoftwareInterrupt(CLINT_TypeDef *CLINTx, uint32_t hartid) {
-  CLEAR_BITS(*(volatile uint32_t *)((CLINTx->MSIP0) + 4 * hartid), 1U);
+  CLEAR_BITS(*(volatile uint32_t *)((&CLINTx->MSIP0) + 4 * hartid), 1U);
 }
 
 static inline void HAL_CLINT_triggerSoftwareInterrupt(CLINT_TypeDef *CLINTx, uint32_t hartid) {
-  SET_BITS(*(volatile uint32_t *)((CLINTx->MSIP0) + 4 * hartid), 1U);
+  SET_BITS(*(volatile uint32_t *)((&CLINTx->MSIP0) + 4 * hartid), 1U);
 }
 
 uint64_t HAL_CLINT_getTime(CLINT_TypeDef *CLINTx);

--- a/common/inc/hal_clint.h
+++ b/common/inc/hal_clint.h
@@ -20,11 +20,11 @@ extern "C" {
 
 
 static inline void HAL_CLINT_clearSoftwareInterrupt(CLINT_TypeDef *CLINTx, uint32_t hartid) {
-  CLEAR_BITS(*(volatile uint32_t *)((&CLINTx->MSIP0) + 4 * hartid), 1U);
+  CLEAR_BITS(CLINTx->MSIP[hart_id], 1U);
 }
 
 static inline void HAL_CLINT_triggerSoftwareInterrupt(CLINT_TypeDef *CLINTx, uint32_t hartid) {
-  SET_BITS(*(volatile uint32_t *)((&CLINTx->MSIP0) + 4 * hartid), 1U);
+  SET_BITS(CLINTx->MSIP[hart_id], 1U);
 }
 
 uint64_t HAL_CLINT_getTime(CLINT_TypeDef *CLINTx);

--- a/common/inc/ll_clint.h
+++ b/common/inc/ll_clint.h
@@ -10,13 +10,8 @@ extern "C" {
 
 /* Peripheral Struct Definition */
 typedef struct {
-  __IO uint32_t MSIP0;                          /** MSIP Registers (1 bit wide) */
-  __IO uint32_t MSIP1;                          /** MSIP Registers (1 bit wide) */
-  __IO uint32_t MSIP2;                          /** MSIP Registers (1 bit wide) */
-  __IO uint32_t MSIP3;                          /** MSIP Registers (1 bit wide) */
-  uint32_t RESERVED0[4092];
-  __IO uint64_t MTIMECMP0;                      /** MTIMECMP Registers */
-  uint32_t RESERVED1[8188];
+  __IO uint32_t MSIP[4096];                     /** MSIP Registers (1 bit wide) */
+  __IO uint64_t MTIMECMP[4095];                 /** MTIMECMP Registers */
   __IO uint64_t MTIME;                          /** Timer Register */
 } CLINT_TypeDef;
 

--- a/common/src/hal_clint.c
+++ b/common/src/hal_clint.c
@@ -11,19 +11,27 @@
 #include "hal_clint.h"
 
 uint64_t HAL_CLINT_getTime(CLINT_TypeDef *CLINTx) {
+  #if __riscv_xlen == 32
   uint32_t time_lo;
   uint32_t time_hi;
 
   do {
-    time_hi = *((volatile uint32_t *)(&CLINTx->MTIME) + 1);
-    time_lo = *((volatile uint32_t *)(&CLINTx->MTIME));
-  } while (*((volatile uint32_t *)(&CLINTx->MTIME) + 1) != time_hi);
+    time_hi = *((__IO uint32_t *)(&CLINTx->MTIME) + 1);
+    time_lo = *((__IO uint32_t *)(&CLINTx->MTIME));
+  } while (*((__IO uint32_t *)(&CLINTx->MTIME) + 1) != time_hi);
 
   return (((uint64_t)time_hi) << 32U) | time_lo;
+  #else
+  return CLINTx->MTIME;
+  #endif
 }
 
 void HAL_CLINT_setTimerInterruptTarget(CLINT_TypeDef *CLINTx, uint32_t hartid, uint64_t time) {
-  *((volatile uint32_t *)(&CLINTx->MTIMECMP0) + 4 * hartid + 1) = 0xffffffff;
-  *((volatile uint32_t *)(&CLINTx->MTIMECMP0) + 4 * hartid) = (uint32_t)time;
-  *((volatile uint32_t *)(&CLINTx->MTIMECMP0) + 4 * hartid + 1) = (uint32_t)(time >> 32);
+  #if __riscv_xlen == 32
+  *((__IO uint32_t *)(&CLINTx->MTIMECMP[hartid] + 1)) = 0xFFFFFFFF;
+  *((__IO uint32_t *)(&CLINTx->MTIMECMP[hartid])) = (uint32_t)time;
+  *((__IO uint32_t *)(&CLINTx->MTIMECMP[hartid])) = (uint32_t)(time >> 32);
+  #else
+  CLINTx->MTIMECMP[hartid] = time;
+  #endif
 }

--- a/common/src/hal_clint.c
+++ b/common/src/hal_clint.c
@@ -15,15 +15,15 @@ uint64_t HAL_CLINT_getTime(CLINT_TypeDef *CLINTx) {
   uint32_t time_hi;
 
   do {
-    time_hi = *((volatile uint32_t *)(CLINTx->MTIME) + 1);
-    time_lo = *((volatile uint32_t *)(CLINTx->MTIME));
-  } while (*((volatile uint32_t *)(CLINTx->MTIME) + 1) != time_hi);
+    time_hi = *((volatile uint32_t *)(&CLINTx->MTIME) + 1);
+    time_lo = *((volatile uint32_t *)(&CLINTx->MTIME));
+  } while (*((volatile uint32_t *)(&CLINTx->MTIME) + 1) != time_hi);
 
   return (((uint64_t)time_hi) << 32U) | time_lo;
 }
 
 void HAL_CLINT_setTimerInterruptTarget(CLINT_TypeDef *CLINTx, uint32_t hartid, uint64_t time) {
-  *((volatile uint32_t *)(CLINTx->MTIMECMP0) + 4 * hartid + 1) = 0xffffffff;
-  *((volatile uint32_t *)(CLINTx->MTIMECMP0) + 4 * hartid) = (uint32_t)time;
-  *((volatile uint32_t *)(CLINTx->MTIMECMP0) + 4 * hartid + 1) = (uint32_t)(time >> 32);
+  *((volatile uint32_t *)(&CLINTx->MTIMECMP0) + 4 * hartid + 1) = 0xffffffff;
+  *((volatile uint32_t *)(&CLINTx->MTIMECMP0) + 4 * hartid) = (uint32_t)time;
+  *((volatile uint32_t *)(&CLINTx->MTIMECMP0) + 4 * hartid + 1) = (uint32_t)(time >> 32);
 }


### PR DESCRIPTION
▹ Fix the missing & address operator in CLINTx.
▹ Improve the CLINT LL definition such that now it supports arbitrary number of cores. Might want to add additional error handling in the future to prevent user from accessing element ids beyong what that SoC has.
▹ Optimize the CLINT timer register operation for SoC with 64-bit bus system.