### PR TITLE
FIX: fix time CSR name

### DIFF
--- a/common/inc/hal_core.h
+++ b/common/inc/hal_core.h
@@ -25,7 +25,7 @@ static inline size_t HAL_CORE_getHartId() {
 }
 
 static inline uint64_t HAL_getTick() {
-  return READ_CSR("mtime");
+  return READ_CSR("time");
 }
 
 static inline void HAL_CORE_disableGlobalInterrupt() {


### PR DESCRIPTION
the CSR name is `time`, not `mtime`